### PR TITLE
Added Project1 and Project1 with Challenges project

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It would be nice to keep the repositories in alphabetical order based on GitHub 
 
 ## Project 1:
 
+* [cweirup](https://github.com/cweirup/100-days-of-swift/tree/master/Project1) - [Challenge](https://github.com/cweirup/100-days-of-swift/tree/master/Project1-Challenges)
 * [CypherPoet](https://github.com/CypherPoet/100-days-of-swift/tree/master/day-018)
 * [robbaldwin](https://github.com/robbaldwin/100DaysOfSwift/tree/master/P01%20StormViewer)
 


### PR DESCRIPTION
I'm starting to add my Projects from 100 Days of Swift. I need to go back and separate out the Challenges from the other Projects, but I've done that already with Project 1.